### PR TITLE
Large refactoring: play well with a JAX workflow

### DIFF
--- a/src/correctionlib_gradients/_base.py
+++ b/src/correctionlib_gradients/_base.py
@@ -2,25 +2,19 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 from functools import partial
-from typing import Any, Callable, Optional, TypeAlias
+from typing import TypeAlias
 
+import correctionlib.schemav2 as schema
 import jax
 import numpy as np
-from correctionlib.schemav2 import Content, Correction
 
-Input: TypeAlias = float
-Output: TypeAlias = tuple[float, dict[str, float]]
-
-
-def isfloat(x: Any) -> bool:
-    if isinstance(x, float):
-        return True
-    if hasattr(x, "dtype") and np.issubdtype(x.dtype, np.floating):
-        return True  # covers numpy and jax arrays
-    return False
+# TODO: switch to use numpy.array_api.Array as _the_ array type.
+# Must wait for it to be out of experimental.
+# See https://numpy.org/doc/stable/reference/array_api.html.
+Value: TypeAlias = float | np.ndarray | jax.Array
 
 
-def apply_ast(ast: Content, correction_name: str, _inputs: dict[str, Input]) -> float:
+def apply_ast(ast: schema.Content, correction_name: str, _inputs: dict[str, Value]) -> Value:
     match ast:
         case float(x):
             return x
@@ -32,50 +26,24 @@ def apply_ast(ast: Content, correction_name: str, _inputs: dict[str, Input]) -> 
             raise NotImplementedError(msg)
 
 
-def grad_wrt_key(
-    f: Callable[[dict[str, Input]], float], wrt: list[str] | None
-) -> Callable[[dict[str, float]], tuple[float, dict[str, float]]]:
-    """Given a callable f that takes a dictionary inputs, return a callable
-    that evaluates the gradient of f w.r.t. one or more of the arrays in
-    the dictionary (specified by key).
-
-    If wrt is None, gradients are taken w.r.t. all floating point inputs.
-    """
-
-    def grad_wrt_impl(inputs: dict[str, float]) -> tuple[float, dict[str, float]]:
-        in_vars = list(inputs.keys())
-        true_wrt = wrt if wrt is not None else [k for k, v in inputs.items() if isfloat(v)]
-        argnums = [in_vars.index(wrt_var) for wrt_var in true_wrt]
-
-        def f_with_positionals(*args: Input) -> float:
-            args_as_dict = dict(zip(in_vars, args))
-            return f(args_as_dict)
-
-        # TODO should we cache df instead of calling value_and_grad at every invocation?
-        df = jax.value_and_grad(f_with_positionals, argnums)
-        value, grads = df(*inputs.values())
-        return value, dict(zip(true_wrt, grads))
-
-    return grad_wrt_impl
-
-
 class CorrectionWithGradient:
-    def __init__(self, c: Correction, *, wrt: Optional[list[str]] = None, jit: bool = False):
-        if len(c.inputs) == 0:
-            msg = "Cannot take gradients of a correction that has no input variables"
-            raise ValueError(msg)
-
-        self._grad_evaluator = grad_wrt_key(partial(apply_ast, c.data, c.name), wrt=wrt)
-        if jit:
-            self._grad_evaluator = jax.jit(self._grad_evaluator)
+    def __init__(self, c: schema.Correction):
+        self._evaluator = partial(apply_ast, c.data, c.name)
         self._input_names = [v.name for v in c.inputs]
         self._name = c.name
 
-    def evaluate(self, inputs: dict[str, Input]) -> Output:
+    def evaluate(self, *inputs: Value) -> Value:
+        if (n_in := len(inputs)) != (n_expected := len(self._input_names)):
+            msg = f"This correction requires {n_expected} input(s), {n_in} provided"
+            raise ValueError(msg)
+
+        input_dict = dict(zip(self._input_names, inputs))
+        return self._evaluator(input_dict)
+
+    def eval_dict(self, inputs: dict[str, Value]) -> Value:
         for n in self._input_names:
             if n not in inputs:
                 msg = f"Variable '{n}' is required by correction '{self._name}' but is not present in input"
                 raise ValueError(msg)
 
-        value, grads = self._grad_evaluator(inputs)
-        return (float(value), grads)
+        return self._evaluator(inputs)

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -3,42 +3,56 @@
 # SPDX-License-Identifier: BSD-3-Clause
 import math
 
+import jax
+import pytest
 from correctionlib import schemav2
-from jax import config
 
 from correctionlib_gradients import CorrectionWithGradient
 
 # we need to set this to avoid loss of precision when jit=True
 # due to JAX aggressively casting everything to float32.
-config.update("jax_enable_x64", True)
+jax.config.update("jax_enable_x64", True)
 
-
-def test_scalar() -> None:
-    c = schemav2.Correction(
+schemas = {
+    "scale": schemav2.Correction(
         name="test scalar",
         version=2,
         inputs=[schemav2.Variable(name="x", type="real")],
         output=schemav2.Variable(name="a scale", type="real"),
         data=1.234,
     )
+}
 
-    dc = CorrectionWithGradient(c)
-    value, gradients = dc.evaluate({"x": 4.2})
-    assert math.isclose(value, 1.234)
-    assert list(gradients.keys()) == ["x"]
-    assert gradients["x"] == 0.0
 
-    # with an extra "y" input of string type
-    dc = CorrectionWithGradient(c, wrt=["x"])
-    value, gradients = dc.evaluate({"x": 4.2, "y": "another"})
-    assert math.isclose(value, 1.234)
-    assert list(gradients.keys()) == ["x"]
-    assert gradients["x"] == 0.0
+def test_wrong_input_length():
+    cg = CorrectionWithGradient(schemas["scale"])
 
-    # with jit=True
-    # the extra "y" variable cannot be a string, jax.jit cannot handle it
-    dc = CorrectionWithGradient(c, wrt=["x"], jit=True)
-    value, gradients = dc.evaluate({"x": 4.2, "y": 42})
+    with pytest.raises(ValueError, match="This correction requires 1 input\\(s\\), 2 provided"):
+        cg.evaluate(0.0, 1.0)
+
+
+def test_missing_input():
+    cg = CorrectionWithGradient(schemas["scale"])
+
+    with pytest.raises(
+        ValueError, match="Variable 'x' is required by correction 'test scalar' but is not present in input"
+    ):
+        cg.eval_dict({})
+
+
+@pytest.mark.parametrize("jit", [False, True])
+def test_scale(jit) -> None:
+    cg = CorrectionWithGradient(schemas["scale"])
+
+    # evaluate
+    evaluate = jax.jit(cg.evaluate) if jit else cg.evaluate
+    value, grad = jax.value_and_grad(evaluate)(4.2)
     assert math.isclose(value, 1.234)
-    assert list(gradients.keys()) == ["x"]
-    assert gradients["x"] == 0.0
+    assert grad.item() == 0.0
+
+    # eval_dict
+    eval_dict = jax.jit(cg.eval_dict) if jit else cg.eval_dict
+    value, grad = jax.value_and_grad(eval_dict)({"x": 4.2})
+    assert math.isclose(value, 1.234)
+    assert list(grad.keys()) == ["x"]
+    assert grad["x"] == 0.0


### PR DESCRIPTION
Instead of applying `jax.grad` internally, expose
`evaluate` and `eval_dict` functions that play
well with `jax.grad` and `jax.jit`.