### PR TITLE
Introduce a JAX-friendly CorrectionDAG object

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
   "Topic :: Scientific/Engineering :: Physics",
 ]
 dependencies = [
-  "correctionlib",
+  "correctionlib@git+https://github.com/eguiraud/correctionlib.git@expose-formula-ast",
   "jax",
   "jaxlib",
   "scipy"
@@ -86,6 +86,9 @@ all = [
   "style",
   "typing",
 ]
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.pytest.ini_options]
 minversion = "7.0"


### PR DESCRIPTION
It's a better representation of the object we want
to evaluate and differentiate. Before this commit
we were implicitly creating something like a
CorrectionDAG on the fly in apply_ast.