### PR TITLE
Move type aliases to their own file

### DIFF
--- a/src/correctionlib_gradients/_base.py
+++ b/src/correctionlib_gradients/_base.py
@@ -9,11 +9,7 @@ import jax
 import numpy as np
 from scipy.interpolate import CubicSpline  # type: ignore[import-not-found]
 
-# TODO: switch to use numpy.array_api.Array as _the_ array type.
-# Must wait for it to be out of experimental.
-# See https://numpy.org/doc/stable/reference/array_api.html.
-Array: TypeAlias = np.ndarray | jax.Array
-Value: TypeAlias = float | Array
+from correctionlib_gradients._typedefs import Array, Value
 
 
 def midpoints(x: Array) -> Array:

--- a/src/correctionlib_gradients/_typedefs.py
+++ b/src/correctionlib_gradients/_typedefs.py
@@ -1,0 +1,10 @@
+from typing import TypeAlias
+
+import jax
+import numpy as np
+
+# TODO: switch to use numpy.array_api.Array as _the_ array type.
+# Must wait for it to be out of experimental.
+# See https://numpy.org/doc/stable/reference/array_api.html.
+Array: TypeAlias = np.ndarray | jax.Array
+Value: TypeAlias = float | Array


### PR DESCRIPTION
They will soon be need to be shared across modules.