### PR TITLE
Allow lists of floats as Values

### DIFF
--- a/src/correctionlib_gradients/_base.py
+++ b/src/correctionlib_gradients/_base.py
@@ -8,17 +8,17 @@ import jax
 import numpy as np
 from scipy.interpolate import CubicSpline  # type: ignore[import-untyped]
 
-from correctionlib_gradients._typedefs import Array, Value
+from correctionlib_gradients._typedefs import Value
 
 
-def midpoints(x: Array) -> Array:
+def midpoints(x: jax.Array) -> jax.Array:
     return 0.5 * (x[1:] + x[:-1])
 
 
 # TODO: the callable returned is not traceable by JAX, so it does not support jax.jit, jax.vmap etc.
 # TODO: would it make more sense if the value returned was the exact value given by the binning,
 #       while the derivative is calculated by spline.derivative?
-def make_differentiable_spline(x: Array, y: Array) -> Callable[[Value], Value]:
+def make_differentiable_spline(x: jax.Array, y: jax.Array) -> Callable[[Value], Value]:
     spline = CubicSpline(midpoints(x), y, bc_type="clamped")
     dspline = spline.derivative(1)
 
@@ -87,7 +87,7 @@ class CorrectionDAG:
                 # to make mypy happy
                 var: str = _var  # type: ignore[has-type]
                 edges: Iterable[float] | schema.UniformBinning = _edges  # type: ignore[has-type]
-                values: Array = _values  # type: ignore[has-type]
+                values: jax.Array = _values  # type: ignore[has-type]
 
                 if isinstance(edges, schema.UniformBinning):
                     xs = np.linspace(edges.low, edges.high, edges.n + 1)

--- a/src/correctionlib_gradients/_typedefs.py
+++ b/src/correctionlib_gradients/_typedefs.py
@@ -6,5 +6,5 @@ import numpy as np
 # TODO: switch to use numpy.array_api.Array as _the_ array type.
 # Must wait for it to be out of experimental.
 # See https://numpy.org/doc/stable/reference/array_api.html.
-Array: TypeAlias = np.ndarray | jax.Array
+Array: TypeAlias = np.ndarray | jax.Array | list[float]
 Value: TypeAlias = float | Array

--- a/src/correctionlib_gradients/_typedefs.py
+++ b/src/correctionlib_gradients/_typedefs.py
@@ -6,5 +6,4 @@ import numpy as np
 # TODO: switch to use numpy.array_api.Array as _the_ array type.
 # Must wait for it to be out of experimental.
 # See https://numpy.org/doc/stable/reference/array_api.html.
-Array: TypeAlias = np.ndarray | jax.Array | list[float]
-Value: TypeAlias = float | Array
+Value: TypeAlias = float | np.ndarray | jax.Array | list[float]

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 import math
+import re
 
 import jax
 import numpy as np
@@ -111,12 +112,28 @@ def test_unsupported_correction():
 
 
 def test_unsupported_compound_binning():
-    with pytest.raises(ValueError, match=""):
+    with pytest.raises(
+        ValueError,
+        match=(
+            re.escape(
+                "Correction 'compound non-uniform binning' contains a compound "
+                "Binning correction (one or more of the bin contents are not "
+                "simple scalars). This is not supported."
+            )
+        ),
+    ):
         CorrectionWithGradient(schemas["compound-nonuniform-binning"])
 
 
 def test_unsupported_flow_type():
-    with pytest.raises(ValueError, match=""):
+    with pytest.raises(
+        ValueError,
+        match=re.escape(
+            "Correction 'simple non-uniform binning with a default value as "
+            "'flow'' contains a Binning correction with `flow=42.0`. "
+            "Only 'clamp' is supported."
+        ),
+    ):
         CorrectionWithGradient(schemas["simple-nonuniform-binning-flow-default"])
 
 


### PR DESCRIPTION
Allow lists of floats as Values

Always use jax.Arrays internally