### PR TITLE
Always run CI on PRs, independently of base branch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: main
   pull_request:
-    branches: main
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
When using graphite, the base branch is often not
`main`, because stacked PRs are opened against
the previous branch.